### PR TITLE
Add FastAPI chatbot backend with LlamaIndex orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+.env
+.venv/
+.mypy_cache/
+pytest_cache/
+.python-version
+.DS_Store
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential curl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md /app/
+COPY app /app/app
+COPY streamlit_app.py /app/streamlit_app.py
+
+RUN pip install --upgrade pip && pip install -e .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,128 @@
+# LlamaIndex Chatbot
+
+This project implements a FastAPI-based chatbot backend orchestrated with **LlamaIndex**. It
+supports conversation persistence in PostgreSQL using async SQLAlchemy, multiple LLM providers
+(OpenAI and Google Gemini), and a lightweight Streamlit client for manual testing.
+
+## Features
+
+- `POST /api/chat` endpoint that accepts a `user_id` and message, returning a response from the
+  selected LLM (OpenAI by default, Gemini available when configured).
+- Conversation history stored durably in PostgreSQL and replayed on every request to maintain
+  context across turns.
+- Optional API key authentication via the `X-API-Key` header stored as hashed values in the
+  database.
+- Automatic table creation on startup (migrations-by-code).
+- Docker and Docker Compose for local development.
+- Streamlit UI for quick testing.
+
+## Project Layout
+
+```
+app/
+  api/               # FastAPI routers and dependencies
+  core/              # Application configuration
+  db/                # Async SQLAlchemy engine, models, and metadata
+  services/          # LLM integration and memory utilities
+  schemas.py         # Pydantic models shared across the API
+  main.py            # FastAPI application entrypoint
+streamlit_app.py     # Streamlit client for manual testing
+Dockerfile           # Backend container definition
+docker-compose.yml   # Orchestrates API, Streamlit UI, and PostgreSQL
+pyproject.toml       # Project dependencies and tooling configuration
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Docker and Docker Compose **or** Python 3.11+ with `pip`.
+- API keys for the LLM providers you want to use:
+  - `OPENAI_API_KEY`
+  - `GOOGLE_API_KEY` (optional unless using Gemini)
+
+### Environment Variables
+
+Create a `.env` file in the project root (or configure environment variables directly) with the
+following values:
+
+```
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/chatbot
+OPENAI_API_KEY=your-openai-key
+GOOGLE_API_KEY=your-google-key
+DEFAULT_LLM_PROVIDER=openai
+MAX_HISTORY_MESSAGES=25
+```
+
+If you want to secure the API using keys, insert hashed keys into the database. You can generate a
+plain/hashed key pair via:
+
+```bash
+python -c "from app.utils import generate_api_key; plain, hashed = generate_api_key('local'); print('plain:', plain); print('hashed:', hashed)"
+```
+
+Then store the hashed value in PostgreSQL:
+
+```sql
+INSERT INTO api_keys (id, name, hashed_key) VALUES (
+    gen_random_uuid(),
+    'local-dev',
+    'hash-from-script'
+);
+```
+
+### Local Development with Docker
+
+```bash
+docker compose up --build
+```
+
+- FastAPI service: http://localhost:8000/docs
+- Streamlit UI: http://localhost:8501
+- PostgreSQL: exposed on port 5432 with default credentials `postgres` / `postgres`.
+
+### Running Locally with Python
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+uvicorn app.main:app --reload
+```
+
+For the Streamlit client, run:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Ensure PostgreSQL is running and reachable based on your `DATABASE_URL`.
+
+## Streamlit Client
+
+The Streamlit client is a simple interface to exercise the chatbot API. It allows you to provide a
+user ID, message, optional API key, and LLM provider override before sending the request. Responses
+are displayed along with the current stored conversation history.
+
+## Testing the API
+
+With the server running, you can test the chat endpoint via `curl`:
+
+```bash
+curl -X POST "http://localhost:8000/api/chat" \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": "user-123", "message": "Hello there"}'
+```
+
+If API keys are enabled, include `-H "X-API-Key: your-key"`.
+
+The response will include the assistant reply, the provider used, and the updated conversation
+history for that user.
+
+## Notes
+
+- The repository intentionally keeps migrations simple by calling `create_all` on startup; for
+  production usage consider integrating Alembic migrations.
+- Configure logging level through the `DEBUG` environment variable.
+- LlamaIndex will use whichever provider is configured via environment variables and the request's
+  `provider` field.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,3 @@
+from .routes import router
+
+__all__ = ["router"]

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -1,0 +1,48 @@
+import hashlib
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.db.models import ApiKey
+from app.db.session import AsyncSessionLocal, get_session
+
+
+settings = get_settings()
+api_key_header = APIKeyHeader(name=settings.api_key_header_name, auto_error=False)
+
+
+def hash_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+async def get_api_key(  # noqa: D401 - FastAPI dependency
+    api_key: Annotated[str | None, Security(api_key_header)]
+) -> ApiKey | None:
+    """Validate the API key if provided; return matching record or None."""
+
+    if api_key is None:
+        return None
+
+    hashed = hash_key(api_key)
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(ApiKey).where(ApiKey.hashed_key == hashed, ApiKey.is_active.is_(True))
+        )
+        record = result.scalar_one_or_none()
+
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )
+
+    return record
+
+
+SessionDep = Annotated[AsyncSession, Depends(get_session)]
+ApiKeyDep = Annotated[ApiKey | None, Depends(get_api_key)]

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, HTTPException, status
+
+from app.api.dependencies import ApiKeyDep, SessionDep
+from app.db.models import MessageRole
+from app.schemas import ChatRequest, ChatResponse, ChatMessageSchema
+from app.services.llm import LLMService
+from app.services.memory import MemoryService
+
+router = APIRouter()
+llm_service = LLMService()
+
+
+@router.post("/chat", response_model=ChatResponse)
+async def chat(
+    payload: ChatRequest,
+    session: SessionDep,
+    _: ApiKeyDep,
+) -> ChatResponse:
+    memory = MemoryService(session)
+    history_records = await memory.fetch_history(payload.user_id)
+
+    history_as_dicts = [
+        {"role": record.role.value, "content": record.content} for record in history_records
+    ]
+
+    try:
+        chat_history = llm_service.to_chat_messages(history_as_dicts)
+        chat_response = llm_service.chat(
+            history=chat_history,
+            user_message=payload.message,
+            provider=payload.provider,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+
+    await memory.record_message(payload.user_id, MessageRole.USER, payload.message)
+    reply_text = chat_response.message or ""
+    await memory.record_message(payload.user_id, MessageRole.ASSISTANT, reply_text)
+    await memory.prune_history(payload.user_id)
+
+    history_records = await memory.fetch_history(payload.user_id)
+
+    raw_payload = chat_response.raw if isinstance(chat_response.raw, dict) else {}
+    provider = raw_payload.get(
+        "model", payload.provider or llm_service.settings.default_llm_provider
+    )
+
+    return ChatResponse(
+        reply=reply_text,
+        provider=str(provider),
+        history=[ChatMessageSchema.model_validate(item) for item in history_records],
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,32 @@
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    app_name: str = "LlamaIndex Chatbot"
+    environment: str = Field("local", env="ENVIRONMENT")
+    debug: bool = Field(False, env="DEBUG")
+
+    database_url: str = Field(
+        "postgresql+asyncpg://postgres:postgres@db:5432/chatbot", env="DATABASE_URL"
+    )
+
+    openai_api_key: str | None = Field(default=None, env="OPENAI_API_KEY")
+    google_api_key: str | None = Field(default=None, env="GOOGLE_API_KEY")
+
+    default_llm_provider: str = Field("openai", env="DEFAULT_LLM_PROVIDER")
+    max_history_messages: int = Field(15, env="MAX_HISTORY_MESSAGES")
+
+    api_key_header_name: str = Field("X-API-Key", env="API_KEY_HEADER_NAME")
+
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+    }
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,11 @@
+from .models import ApiKey, ConversationMessage, MessageRole
+from .session import AsyncSessionLocal, get_session, init_models
+
+__all__ = [
+    "ApiKey",
+    "ConversationMessage",
+    "MessageRole",
+    "AsyncSessionLocal",
+    "get_session",
+    "init_models",
+]

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,34 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Enum, String, Text, Boolean
+from sqlalchemy.dialects.postgresql import UUID
+
+from .base import Base
+
+
+class MessageRole(str, enum.Enum):
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+
+
+class ConversationMessage(Base):
+    __tablename__ = "conversation_messages"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(String(255), index=True, nullable=False)
+    role = Column(Enum(MessageRole), nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ApiKey(Base):
+    __tablename__ = "api_keys"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String(255), nullable=False)
+    hashed_key = Column(String(255), nullable=False, unique=True)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,23 @@
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import get_settings
+from .base import Base
+
+
+settings = get_settings()
+engine = create_async_engine(settings.database_url, echo=settings.debug)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    async with AsyncSessionLocal() as session:
+        yield session
+
+
+async def init_models() -> None:
+    from app.db import models  # noqa: F401
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,32 @@
+import logging
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.api.routes import router as api_router
+from app.core.config import get_settings
+from app.db.session import init_models
+
+settings = get_settings()
+logging.basicConfig(level=logging.INFO if not settings.debug else logging.DEBUG)
+
+app = FastAPI(title=settings.app_name)
+app.include_router(api_router, prefix="/api")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_models()
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class ChatRole(str, Enum):
+    user = "user"
+    assistant = "assistant"
+    system = "system"
+
+
+class ChatRequest(BaseModel):
+    user_id: str = Field(..., example="user-123")
+    message: str = Field(..., example="Hello, bot!")
+    provider: str | None = Field(None, description="Optional LLM provider override")
+
+
+class ChatMessageSchema(BaseModel):
+    role: ChatRole
+    content: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ChatResponse(BaseModel):
+    reply: str
+    provider: str
+    history: list[ChatMessageSchema]

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,4 @@
+from .llm import LLMService, LLMProvider
+from .memory import MemoryService
+
+__all__ = ["LLMService", "LLMProvider", "MemoryService"]

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+from enum import Enum
+
+from llama_index.core.llms import ChatMessage, MessageRole
+from llama_index.core.llms.types import ChatResponse
+from llama_index.llms.gemini import Gemini
+from llama_index.llms.openai import OpenAI
+
+from app.core.config import get_settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class LLMProvider(str, Enum):
+    OPENAI = "openai"
+    GEMINI = "gemini"
+
+
+class LLMService:
+    def __init__(self) -> None:
+        self.settings = get_settings()
+
+    def _get_llm(self, provider: LLMProvider) -> OpenAI | Gemini:
+        if provider is LLMProvider.OPENAI:
+            if not self.settings.openai_api_key:
+                raise RuntimeError("OPENAI_API_KEY is not configured")
+            return OpenAI(api_key=self.settings.openai_api_key)
+        if provider is LLMProvider.GEMINI:
+            if not self.settings.google_api_key:
+                raise RuntimeError("GOOGLE_API_KEY is not configured")
+            return Gemini(api_key=self.settings.google_api_key)
+        raise ValueError(f"Unsupported provider: {provider}")
+
+    def _resolve_provider(self, preferred: str | None) -> LLMProvider:
+        if preferred:
+            try:
+                return LLMProvider(preferred.lower())
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise ValueError(f"Unknown LLM provider '{preferred}'") from exc
+        return LLMProvider(self.settings.default_llm_provider.lower())
+
+    def chat(
+        self,
+        *,
+        history: list[ChatMessage],
+        user_message: str,
+        provider: str | None,
+    ) -> ChatResponse:
+        llm_provider = self._resolve_provider(provider)
+        llm = self._get_llm(llm_provider)
+
+        messages = history + [ChatMessage(role=MessageRole.USER, content=user_message)]
+        logger.debug("Dispatching %d messages to %s", len(messages), llm_provider.value)
+        return llm.chat(messages=messages)
+
+    @staticmethod
+    def to_chat_messages(records: list[dict[str, str]]) -> list[ChatMessage]:
+        chat_messages: list[ChatMessage] = []
+        for record in records:
+            role = MessageRole(record["role"])
+            chat_messages.append(ChatMessage(role=role, content=record["content"]))
+        return chat_messages

--- a/app/services/memory.py
+++ b/app/services/memory.py
@@ -1,0 +1,53 @@
+from collections.abc import Sequence
+
+from sqlalchemy import desc, delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import get_settings
+from app.db.models import ConversationMessage, MessageRole
+
+
+settings = get_settings()
+
+
+class MemoryService:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def record_message(self, user_id: str, role: MessageRole, content: str) -> None:
+        message = ConversationMessage(user_id=user_id, role=role, content=content)
+        self.session.add(message)
+        await self.session.commit()
+
+    async def fetch_history(self, user_id: str) -> Sequence[ConversationMessage]:
+        stmt = (
+            select(ConversationMessage)
+            .where(ConversationMessage.user_id == user_id)
+            .order_by(desc(ConversationMessage.created_at))
+            .limit(settings.max_history_messages)
+        )
+        result = await self.session.execute(stmt)
+        records = list(result.scalars().all())
+        records.reverse()
+        return records
+
+    async def prune_history(self, user_id: str, max_messages: int | None = None) -> None:
+        """Ensure only the most recent messages are kept."""
+        max_messages = max_messages or settings.max_history_messages
+        stmt = (
+            select(ConversationMessage.id)
+            .where(ConversationMessage.user_id == user_id)
+            .order_by(desc(ConversationMessage.created_at))
+        )
+        result = await self.session.execute(stmt)
+        ids = result.scalars().all()
+        excess = len(ids) - max_messages
+        if excess <= 0:
+            return
+        ids_to_delete = ids[max_messages:]
+        if not ids_to_delete:
+            return
+        await self.session.execute(
+            delete(ConversationMessage).where(ConversationMessage.id.in_(ids_to_delete))
+        )
+        await self.session.commit()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,10 @@
+import secrets
+
+from app.api.dependencies import hash_key
+
+
+def generate_api_key(name: str) -> tuple[str, str]:
+    """Generate a plain API key and its hash for insertion into the database."""
+    plain = secrets.token_urlsafe(32)
+    hashed = hash_key(plain)
+    return plain, hashed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: chatbot
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  api:
+    build: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/chatbot
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      DEFAULT_LLM_PROVIDER: ${DEFAULT_LLM_PROVIDER:-openai}
+    volumes:
+      - ./:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  streamlit:
+    build: .
+    command: streamlit run streamlit_app.py --server.port 8501 --server.address 0.0.0.0
+    environment:
+      API_BASE_URL: http://api:8000/api
+      STREAMLIT_SERVER_PORT: 8501
+    volumes:
+      - ./:/app
+    ports:
+      - "8501:8501"
+    depends_on:
+      - api
+
+volumes:
+  postgres_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=62", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llamaindex-chatbot"
+version = "0.1.0"
+description = "FastAPI chatbot with LlamaIndex and PostgreSQL"
+readme = "README.md"
+authors = [{name = "PAIA", email = "dev@example.com"}]
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "sqlalchemy[asyncio]",
+    "asyncpg",
+    "pydantic>=2.0",
+    "pydantic-settings",
+    "llama-index>=0.10.0",
+    "openai>=1.0.0",
+    "google-generativeai",
+    "python-dotenv",
+    "streamlit",
+    "httpx",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "ruff",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,47 @@
+import os
+from typing import Any
+
+import httpx
+import streamlit as st
+
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000/api")
+
+st.set_page_config(page_title="LlamaIndex Chatbot", page_icon="🤖")
+st.title("🤖 LlamaIndex Chatbot Tester")
+
+with st.sidebar:
+    st.header("Configuration")
+    user_id = st.text_input("User ID", value="demo-user")
+    provider = st.selectbox("Provider", options=["default", "openai", "gemini"], index=0)
+    api_key = st.text_input("API Key", value="", type="password")
+    submit_on_enter = st.checkbox("Send on Enter", value=True)
+
+chat_container = st.container()
+user_message = st.text_input("Message", value="Hello there!", key="message_input")
+
+if st.button("Send") or (submit_on_enter and user_message and st.session_state.get("enter_pressed")):
+    payload: dict[str, Any] = {"user_id": user_id, "message": user_message}
+    if provider != "default":
+        payload["provider"] = provider
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+
+    with st.spinner("Contacting chatbot..."):
+        try:
+            response = httpx.post(f"{API_BASE_URL}/chat", json=payload, headers=headers, timeout=60.0)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - UI feedback only
+            st.error(f"Request failed: {exc}")
+        else:
+            data = response.json()
+            chat_container.markdown(f"**Assistant ({data['provider']}):** {data['reply']}")
+            st.session_state.setdefault("history", []).append((user_message, data["reply"]))
+            if data.get("history"):
+                st.subheader("Conversation History")
+                for item in data["history"]:
+                    st.markdown(f"- **{item['role']}**: {item['content']}")
+
+if submit_on_enter:
+    st.session_state["enter_pressed"] = user_message.endswith("\n")


### PR DESCRIPTION
## Summary
- create a FastAPI application with a chat endpoint that stores conversations in PostgreSQL through async SQLAlchemy
- integrate LlamaIndex-backed services for OpenAI and Gemini responses while persisting messages as durable memory
- add local tooling with Docker, Docker Compose, Streamlit UI, and project metadata for package management

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcfb9e21248327b98c61d3613b6747